### PR TITLE
Remove support for Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ QUAlibrate is an open-source calibration platform designed specifically for quan
 ## Installation
 
 **Requirements**
-QUAlibrate requires Python ≥ 3.9. It is also recommended to use a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
+QUAlibrate requires 3.9 ≤ Python ≤ 3.11. It is also recommended to use a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
 
 1. **Install QUAlibrate**
    Run the following command in a terminal:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This guide will provide a detailed walkthrough for installing QUAlibrate, a user
 
 /// tab | For Windows
 - Windows 10 (build 1809 and later), or Windows 11
-- Python ≥ 3.9, we recommend Python 3.10 or higher
+- 3.9 ≤ Python ≤ 3.11, we recommend Python 3.10 or 3.11
 
 /// details | Using a virtual environment in Windows
     type: tip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "qualibrate_composite" }]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.9,<3.12"
 pydantic = "^2.7.4"
 pydantic-settings = "^2.3.4"
 click = "^8.1.7"


### PR DESCRIPTION
Otherwise the installation on Python 3.12 fails due to a dependency on `qualang_tools` which doesn't support Python 3.12